### PR TITLE
Add OIDC and HTI endpoints with keypair and JWT support

### DIFF
--- a/generate_claim_token_from_access_grant.mjs
+++ b/generate_claim_token_from_access_grant.mjs
@@ -1,0 +1,59 @@
+const claimToken = {
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1"
+    ],
+    "type": [
+        "VerifiablePresentation"
+    ],
+    "verifiableCredential": []
+}
+
+const accessGrant = {
+    "id": "https://vc.sandbox-pod.datanutsbedrijf.be/vc/65741eb1-9b74-4258-91e8-9a69b88809fa",
+    "type": [
+        "VerifiableCredential",
+        "SolidAccessGrant"
+    ],
+    "proof": {
+        "type": "Ed25519Signature2020",
+        "created": "2025-04-01T08:01:13.503Z",
+        "domain": "solid",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z5qmtJ6KeSZ2zw9PJ4jMNqQoMxPEmrH7vHecUQvLtSwsnxB6cSJFXZFB6v4dSL6qjZa5pNS77HcdEmqSW4GH4ToJz",
+        "verificationMethod": "https://vc.sandbox-pod.datanutsbedrijf.be/key/b7356870-a180-3bfb-bea9-f9a13cd7b04e"
+    },
+    "credentialStatus": {
+        "id": "https://vc.sandbox-pod.datanutsbedrijf.be/status/oLch#0",
+        "type": "RevocationList2020Status",
+        "revocationListCredential": "https://vc.sandbox-pod.datanutsbedrijf.be/status/oLch",
+        "revocationListIndex": "0"
+    },
+    "credentialSubject": {
+        "id": "https://tni.webid.burgerprofiel.dev-vlaanderen.be/profiles/05be274a-21bf-4b25-8900-1899e0599316",
+        "providedConsent": {
+            "mode": [
+                "Read",
+                "Append",
+                "Write"
+            ],
+            "forPersonalData": "https://storage.sandbox-pod.datanutsbedrijf.be/6a43495b-98fb-4df8-a608-69225cec06c3/book_index",
+            "hasStatus": "ConsentStatusExplicitlyGiven",
+            "isProvidedTo": "https://id.we-are-acc.vito.be/24718a19-4d75-4925-b99c-db103bfba9f5"
+        }
+    },
+    "expirationDate": "2025-09-28T08:01:13.489713189Z",
+    "issuanceDate": "2025-04-01T08:01:13.489Z",
+    "issuer": "https://vc.sandbox-pod.datanutsbedrijf.be",
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.inrupt.com/credentials/v2.jsonld",
+        "https://w3id.org/security/data-integrity/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+        "https://w3id.org/vc/status-list/2021/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1"
+    ]
+}
+
+claimToken.verifiableCredential.push(accessGrant)
+
+console.log(Buffer.from(JSON.stringify(claimToken)).toString('base64'));

--- a/generate_code_verifier_and_challenge.mjs
+++ b/generate_code_verifier_and_challenge.mjs
@@ -1,0 +1,32 @@
+import { createHash, randomBytes } from "crypto";
+
+let encode;
+if (Buffer.isEncoding('base64url')) {
+    encode = (input, encoding = 'utf8') => Buffer.from(input, encoding).toString('base64url');
+} else {
+    const fromBase64 = (base64) => base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+    encode = (input, encoding = 'utf8') =>
+        fromBase64(Buffer.from(input, encoding).toString('base64'));
+}
+
+const decode = (input) => Buffer.from(input, 'base64');
+
+const random = (bytes = 32) => encode(randomBytes(bytes));
+
+const state =  random;
+const nonce = random;
+const codeVerifier = random;
+const codeChallenge = (codeVerifier) =>
+    encode(createHash('sha256').update(codeVerifier).digest())
+
+const stateValue =  random();
+const nonceValue = random();
+const codeVerifierValue = random();
+const codeChallengeValue = codeChallenge(codeVerifierValue);
+
+console.log(`
+    State Value: ${stateValue}
+    Nonce Value: ${nonceValue}
+    Code Verifier Value: ${codeVerifierValue}
+    Code Challenge Value: ${codeChallengeValue}
+`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "express": "^4.21.2",
         "express-http-context": "^1.2.4",
         "express-session": "^1.18.1",
-        "loglevel": "^1.9.2"
+        "jose": "^6.0.10",
+        "loglevel": "^1.9.2",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -79,6 +81,15 @@
         "@inrupt/solid-client-authn-core": "^2.3.0",
         "jose": "^5.1.3",
         "uuid": "^11.0.3"
+      }
+    },
+    "node_modules/@inrupt/oidc-client-ext/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@inrupt/oidc-client/node_modules/acorn": {
@@ -148,6 +159,15 @@
         "uuid": "^11.0.3"
       }
     },
+    "node_modules/@inrupt/solid-client-authn-browser/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@inrupt/solid-client-authn-core": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.3.0.tgz",
@@ -159,6 +179,15 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-core/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
@@ -173,6 +202,15 @@
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-node/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@inrupt/solid-client-errors": {
@@ -732,6 +770,15 @@
         "uuid": "^11.0.5"
       }
     },
+    "node_modules/@vito-nv/weare-core/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@vito-nv/weare-expressjs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vito-nv/weare-expressjs/-/weare-expressjs-1.0.0.tgz",
@@ -1094,6 +1141,7 @@
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -1567,9 +1615,10 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/jose": {
-      "version": "5.9.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
-      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
+      "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2447,13 +2496,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "@vito-nv/weare-core": "^1.0.0",
     "@vito-nv/weare-expressjs": "^1.0.0",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-http-context": "^1.2.4",
     "express-session": "^1.18.1",
+    "jose": "^6.0.10",
     "loglevel": "^1.9.2",
-    "dotenv": "^16.4.7"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,8 @@ import {sessionEndpoint} from "./endpoint/session-endpoint";
 import vcEndpoint from "./endpoint/vc-endpoint";
 import {initializeEnvironment} from "./validate/environment-validate";
 import path from "path";
+import {oidcEndpoint} from "./endpoint/oidc-endpoint";
+import {htiEndpoint} from "./endpoint/hti-endpoints";
 
 // Load environment variables from the `.env` file into `process.env`
 dotEnv.config();
@@ -106,6 +108,8 @@ app.use(bodyParser.raw());
  * These functions define routes and their handlers for the application.
  */
 authenticationEndpoint(app);
+oidcEndpoint(app)
+htiEndpoint(app)
 podEndpoint(app);
 sessionEndpoint(app);
 vcEndpoint(app);

--- a/src/endpoint/authentication-endpoint.ts
+++ b/src/endpoint/authentication-endpoint.ts
@@ -39,11 +39,10 @@ export function authenticationEndpoint(app: Express) {
       if(session?.info.isLoggedIn)
         await session.logout({logoutType: 'app'});
 
-      if (!session)
+      if (!session) {
         session = new Session( {storage: globalThis.solidStorage!, keepAlive: false});
-
-      if(!req.session.solidSid)
         req.session.solidSid = session.info.sessionId;
+      }
 
       if (req.query.redirectUrl)
         req.session.redirectUrl = (new URL(req.query.redirectUrl as string)).href;

--- a/src/endpoint/hti-endpoints.ts
+++ b/src/endpoint/hti-endpoints.ts
@@ -1,0 +1,23 @@
+import {Express} from "express";
+import {getLaunchToken} from "../service/hti-service";
+import {getSession, getSessionMandatory} from "@vito-nv/weare-expressjs";
+
+export function htiEndpoint(app: Express) {
+    app.get("/hti-launch", getSession.bind({ storage: globalThis.solidStorage }), async (req, res, next) => {
+        let hostHeader = req.header('host');
+        if (!req.query.webId || !req.query.redirectUrl) {
+            res.status(400).send("Missing webId or redirectUrl in the request query parameters.");
+            return;
+        }
+        console.log(req.query.redirectUrl);
+        let launch_token = await getLaunchToken({
+            iss: `${req.protocol}://${hostHeader}`,
+            sub: req.query.webId as string,
+            redirectUrl: req.query.redirectUrl as string,
+        });
+        res.json({
+            launch_token: launch_token
+        });
+    });
+
+}

--- a/src/endpoint/hti-endpoints.ts
+++ b/src/endpoint/hti-endpoints.ts
@@ -1,23 +1,29 @@
 import {Express} from "express";
-import {getLaunchToken} from "../service/hti-service";
-import {getSession, getSessionMandatory} from "@vito-nv/weare-expressjs";
+import {createLaunchToken} from "../service/hti-service";
+import {getSessionMandatory} from "@vito-nv/weare-expressjs";
+import log from "loglevel";
 
 export function htiEndpoint(app: Express) {
-    app.get("/hti-launch", getSession.bind({ storage: globalThis.solidStorage }), async (req, res, next) => {
-        let hostHeader = req.header('host');
+    app.get("/create-hti", async (req, res, next) => {
+        log.debug("Endpoint '/create-hti' called");
+
         if (!req.query.webId || !req.query.redirectUrl) {
             res.status(400).send("Missing webId or redirectUrl in the request query parameters.");
             return;
         }
-        console.log(req.query.redirectUrl);
-        let launch_token = await getLaunchToken({
-            iss: `${req.protocol}://${hostHeader}`,
-            sub: req.query.webId as string,
-            redirectUrl: req.query.redirectUrl as string,
-        });
+
+        next();
+    }, getSessionMandatory.bind({ storage: globalThis.solidStorage }), async (req, res) => {
+        let launchToken = await createLaunchToken(
+            new URL(`${process.env['PROTOCOL']}://${req.get("host")}`), // This is required due to intermediate proxies that might perform TLS offloading
+            req.query.webId as string,
+            new URL(req.query.redirectUrl as string)
+        );
         res.json({
-            launch_token: launch_token
+            launchToken
         });
+
+        return;
     });
 
 }

--- a/src/endpoint/oidc-endpoint.ts
+++ b/src/endpoint/oidc-endpoint.ts
@@ -1,0 +1,30 @@
+import {Express} from "express";
+import {getResource, getSessionOptional} from "@vito-nv/weare-expressjs";
+import {getKeyPair} from "../service/keypair.service";
+
+export function oidcEndpoint(app: Express) {
+
+    app.get("/.well-known/oidc-configuration", async (req, res, next) => {
+        next();
+    }, async (req, res, next) => {
+        let hostHeader = req.header('host');
+
+        const oidcConfiguration = {
+            "issuer": `${req.protocol}://${hostHeader}`,
+            "jwks_uri": `${req.protocol}://${hostHeader}/.well-known/jwks.json`
+        }
+        res.json(oidcConfiguration);
+    });
+
+    app.get("/.well-known/jwks.json", async (req, res, next) => {
+        next();
+    }, async (req, res, next) => {
+        let keyPair = await getKeyPair();
+        const jwks = {
+            keys: [
+                keyPair.publicKey
+            ]
+        }
+        res.json(jwks)
+    })
+}

--- a/src/service/hti-service.ts
+++ b/src/service/hti-service.ts
@@ -1,0 +1,25 @@
+import {SignJWT} from "jose";
+import {getKeyPair} from "./keypair.service";
+import {v4} from "uuid";
+
+interface LaunchUrlRequest {
+    redirectUrl: string;
+    sub: string;
+    iss: string;
+}
+
+export async function getLaunchToken(req:LaunchUrlRequest) {
+    let keyPair = await getKeyPair();
+    return await new SignJWT({})
+        .setIssuer(req.iss)
+        .setAudience(req.redirectUrl)
+        .setSubject(req.sub)
+        .setExpirationTime("15m")
+        .setProtectedHeader({alg: "RS512", typ: "JWT", kid: keyPair.publicKey.kid})
+        .setIssuedAt()
+        .setNotBefore(
+            "10s"
+        )
+        .setJti(v4())
+        .sign(keyPair.privateKey);
+}

--- a/src/service/hti-service.ts
+++ b/src/service/hti-service.ts
@@ -2,24 +2,18 @@ import {SignJWT} from "jose";
 import {getKeyPair} from "./keypair.service";
 import {v4} from "uuid";
 
-interface LaunchUrlRequest {
-    redirectUrl: string;
-    sub: string;
-    iss: string;
-}
-
-export async function getLaunchToken(req:LaunchUrlRequest) {
+export async function createLaunchToken(issuer: URL, subject: string, recipient: URL) {
     let keyPair = await getKeyPair();
     return await new SignJWT({})
-        .setIssuer(req.iss)
-        .setAudience(req.redirectUrl)
-        .setSubject(req.sub)
-        .setExpirationTime("15m")
-        .setProtectedHeader({alg: "RS512", typ: "JWT", kid: keyPair.publicKey.kid})
-        .setIssuedAt()
-        .setNotBefore(
-            "10s"
-        )
-        .setJti(v4())
-        .sign(keyPair.privateKey);
+    .setIssuer(issuer.href)
+    .setAudience(recipient.href)
+    .setSubject(subject)
+    .setExpirationTime("15m")
+    .setProtectedHeader({alg: "RS512", typ: "JWT", kid: keyPair.publicKey.kid})
+    .setIssuedAt()
+    .setNotBefore(
+        "10s"
+    )
+    .setJti(v4())
+    .sign(keyPair.privateKey);
 }

--- a/src/service/keypair.service.ts
+++ b/src/service/keypair.service.ts
@@ -1,0 +1,42 @@
+import {calculateJwkThumbprint, exportJWK, generateKeyPair} from "jose";
+import type * as types from "jose/dist/types/types";
+
+interface KeyPair {
+    publicKey: types.JWK
+    privateKey: types.JWK
+}
+
+var keyPair: KeyPair
+
+export async function getKeyPair(): Promise<KeyPair> {
+    if (!keyPair) {
+        keyPair = await createKeyPairInternal()
+    }
+    return keyPair
+}
+
+async function createKeyPairInternal(): Promise<KeyPair> {
+
+    let keyPair
+    let alg
+    let crv
+    alg = 'RS512';
+    const { publicKey, privateKey } = await generateKeyPair(alg, {
+        modulusLength: 2048,
+        extractable: true,
+    });
+
+    const jwk = await exportJWK(publicKey)
+    const jwkPrivate = await exportJWK(privateKey)
+    jwk.alg = alg
+    if (crv) {
+        jwk.crv = crv
+    }
+    jwk.kid = await calculateJwkThumbprint(jwk)
+
+    jwkPrivate.alg = alg
+    return {
+        publicKey: jwk,
+        privateKey: jwkPrivate
+    }
+}

--- a/src/service/keypair.service.ts
+++ b/src/service/keypair.service.ts
@@ -16,27 +16,20 @@ export async function getKeyPair(): Promise<KeyPair> {
 }
 
 async function createKeyPairInternal(): Promise<KeyPair> {
-
-    let keyPair
-    let alg
-    let crv
-    alg = 'RS512';
-    const { publicKey, privateKey } = await generateKeyPair(alg, {
+    const algorithm = 'RS512';
+    const { publicKey, privateKey } = await generateKeyPair(algorithm, {
         modulusLength: 2048,
         extractable: true,
     });
 
-    const jwk = await exportJWK(publicKey)
-    const jwkPrivate = await exportJWK(privateKey)
-    jwk.alg = alg
-    if (crv) {
-        jwk.crv = crv
-    }
-    jwk.kid = await calculateJwkThumbprint(jwk)
+    const publicJwk = await exportJWK(publicKey)
+    const privateJwk = await exportJWK(privateKey)
+    publicJwk.alg = algorithm
+    publicJwk.kid = await calculateJwkThumbprint(publicJwk)
 
-    jwkPrivate.alg = alg
+    privateJwk.alg = algorithm
     return {
-        publicKey: jwk,
-        privateKey: jwkPrivate
+        publicKey: publicJwk,
+        privateKey: privateJwk
     }
 }


### PR DESCRIPTION
Introduced `oidc-endpoint` and `hti-endpoints` to enable OIDC configuration and HTI launch functionality.
Implemented supporting services (`keypair.service` and `hti-service`) for JWT creation and keypair generation. 
Updated dependencies to include `jose`, `uuid`, and others to support these features.